### PR TITLE
docs: #841 - [M1-P3] Update maintenance documentation for add_concentration charge support

### DIFF
--- a/adw-docs/dev-plans/README.md
+++ b/adw-docs/dev-plans/README.md
@@ -15,7 +15,7 @@ and rollout.
 ## Maintenance Plans
 
 - [Add Charge Support to add_concentration][plan-charge-add-concentration] —
-  Status: Not Started (P2)
+  Status: Shipped (P2)
   - Scope: Enable `add_concentration()` to accept optional charge parameter for
     ion injection in coagulation simulations.
 

--- a/adw-docs/dev-plans/maintenance/M1-add-concentration-charge-support.md
+++ b/adw-docs/dev-plans/maintenance/M1-add-concentration-charge-support.md
@@ -2,8 +2,8 @@
 
 **ID:** M1
 **Priority:** P2
-**Status:** Not Started
-**Last Updated:** 2025-12-19
+**Status:** Shipped
+**Last Updated:** 2025-12-23
 
 ## Priority Justification
 
@@ -93,23 +93,23 @@ and `ParticleRepresentation.add_concentration()`.
 **Size:** S (~50-70 LOC including tests)
 
 **Tasks:**
-- [ ] Update `DistributionStrategy.add_concentration()` abstract signature to
+- [x] Update `DistributionStrategy.add_concentration()` abstract signature to
       include `added_charge: Optional[NDArray[np.float64]] = None`
-- [ ] Update return type to include optional charge array
-- [ ] Implement charge handling in `ParticleResolvedSpeciatedMass.add_concentration()`:
+- [x] Update return type to include optional charge array
+- [x] Implement charge handling in `ParticleResolvedSpeciatedMass.add_concentration()`:
   - Append charge values for new particles
   - Fill empty bins with provided charge or default to 0
-- [ ] Update `ParticleRepresentation.add_concentration()` to:
+- [x] Update `ParticleRepresentation.add_concentration()` to:
   - Accept `*, added_charge: Optional[NDArray[np.float64]] = None` (keyword-only)
   - Pass charge to strategy and update `self.charge`
-- [ ] Add tests for particle-resolved charge addition scenarios
-- [ ] Update docstrings documenting ParticleResolved behavior
+- [x] Add tests for particle-resolved charge addition scenarios
+- [x] Update docstrings documenting ParticleResolved behavior
 
 **Acceptance Criteria:**
-- [ ] New ions can be added with specified charges
-- [ ] Missing charge defaults to 0 for new particles
-- [ ] Existing calls without `added_charge` continue to work
-- [ ] Tests cover append, fill-empty, and partial-fill scenarios with charge
+- [x] New ions can be added with specified charges
+- [x] Missing charge defaults to 0 for new particles
+- [x] Existing calls without `added_charge` continue to work
+- [x] Tests cover append, fill-empty, and partial-fill scenarios with charge
 
 ### Phase 2: Bin-Based Strategy Charge Support (M1-P2)
 
@@ -119,18 +119,18 @@ averaging.
 **Size:** S (~50-70 LOC including tests)
 
 **Tasks:**
-- [ ] Implement charge handling in `MassBasedMovingBin.add_concentration()`:
+- [x] Implement charge handling in `MassBasedMovingBin.add_concentration()`:
   - Compute concentration-weighted average charge when adding to bins
   - Default to existing charge when `added_charge=None`
-- [ ] Implement same pattern in `RadiiBasedMovingBin.add_concentration()`
-- [ ] Implement same pattern in `SpeciatedMassMovingBin.add_concentration()`
-- [ ] Add tests for bin-based charge averaging scenarios
-- [ ] Update docstrings documenting bin-based behavior differences
+- [x] Implement same pattern in `RadiiBasedMovingBin.add_concentration()`
+- [x] Implement same pattern in `SpeciatedMassMovingBin.add_concentration()`
+- [x] Add tests for bin-based charge averaging scenarios
+- [x] Update docstrings documenting bin-based behavior differences
 
 **Acceptance Criteria:**
-- [ ] Adding concentration updates charge via weighted average
-- [ ] Missing charge preserves existing bin charges
-- [ ] Docstrings clearly explain bin-based vs particle-resolved behavior
+- [x] Adding concentration updates charge via weighted average
+- [x] Missing charge preserves existing bin charges
+- [x] Docstrings clearly explain bin-based vs particle-resolved behavior
 
 ### Phase 3: Documentation Update (M1-P3)
 
@@ -139,9 +139,9 @@ averaging.
 **Size:** XS
 
 **Tasks:**
-- [ ] Update this maintenance document status to Shipped
-- [ ] Add completion notes and lessons learned
-- [ ] Update README.md in development_plans if needed
+- [x] Update this maintenance document status to Shipped
+- [x] Add completion notes and lessons learned
+- [x] Update README.md in development_plans if needed
 
 ## Technical Approach
 
@@ -269,6 +269,27 @@ new_charge[i] = (old_concentration[i] * old_charge[i] + added_concentration[i] *
 - **Developer Impact:** Consistent charge handling across particle operations
 - **System Impact:** Minor API addition, fully backward compatible
 
+## Completion Notes
+
+### Implementation Summary
+
+- **Phase 1 (#78):** Added keyword-only `added_charge` handling in
+  `ParticleRepresentation` and particle-resolved strategy, including tests for
+  append/fill paths.
+- **Phase 2 (#79):** Implemented concentration-weighted charge updates across
+  bin-based strategies with documentation and coverage.
+
+### Lessons Learned
+
+- Align charge array shape validation early to avoid downstream errors.
+- Maintain parity between particle-resolved and bin-based docstrings to reduce
+  support questions.
+
+### Actual vs Planned
+
+- Matched plan; all phases shipped as scheduled with backward compatibility
+  confirmed.
+
 ## References
 
 - Related Architecture: Strategy pattern in `distribution_strategies/`
@@ -299,3 +320,4 @@ When generating issues from this maintenance plan:
 | Date | Change | Author |
 |------|--------|--------|
 | 2025-12-19 | Initial maintenance plan created | ADW Workflow |
+| 2025-12-23 | Feature shipped - all phases complete | ADW Workflow |


### PR DESCRIPTION
> **Fixes #841** | Workflow: `ac8451b3`

## Summary

Finalizes the maintenance plan for add_concentration charge support by marking the work as shipped, adding completion notes, and keeping the development plans index in sync. These updates bring the documentation into alignment with the merged Phase 1 (#78) and Phase 2 (#79) work that already landed.

## What Changed

### Modified Components

- `adw-docs/dev-plans/maintenance/M1-add-concentration-charge-support.md` – Updated the header to show the plan as Shipped, refreshed the last-updated date, added a structured Completion Notes section (implementation summary, lessons learned, actual vs planned), toggled all phase/task/acceptance checkboxes to `[x]`, and appended a second row to the Change Log describing the shipped status.
- `adw-docs/dev-plans/README.md` – Updated the Add Charge Support entry to report “Status: Shipped (P2)” so the index reflects the completed maintenance work without disturbing the existing reference link.

## How It Works

The document now reflects the final state of the charge-support work: the header records the ship date, the Completion Notes section summarizes Phases 1 and 2 plus lessons learned, and the change-log entry provides an audit trail while the README entry flags the plan as shipped. All checkboxes within the plan are set to `[x]`, confirming each phase/task/acceptance criterion has been addressed.

## Implementation Notes

- **Why this approach:** The plan already documented the API phases; these edits ensure the maintenance tracking docs capture the shipped status without reworking the underlying template or checklist.
- **Cross-references:** All reference links (`[plan-charge-add-concentration]`) remain untouched so existing anchors keep resolving.

## Testing

- Not run (documentation-only change)
