### PR TITLE
fix: #843 - Fix NumPy 2.0 TypeError in `util.get_shape_check` - array scalar conversion

### DIFF
--- a/particula/util/convert_dtypes.py
+++ b/particula/util/convert_dtypes.py
@@ -172,9 +172,9 @@ def get_shape_check(
             concatenate_axis_new = 1  # Default to the axis=1
         else:
             # Find the axis that doesn't match the length of time
-            concatenate_axis_new = np.argwhere(
-                np.array(data.shape) != len(time)
-            ).flatten()[0]
+            indices = np.argwhere(np.array(data.shape) != len(time)).flatten()
+            # NumPy 2.0 requires a Python int for axis values
+            concatenate_axis_new = int(indices[0].item())
         # Reshape new data so the concatenate axis is axis=1
         data = np.moveaxis(data, concatenate_axis_new, 1)
 

--- a/particula/util/tests/convert_dtypes_test.py
+++ b/particula/util/tests/convert_dtypes_test.py
@@ -71,3 +71,17 @@ def test_get_shape_check_2d_and_header():
         get_shape_check(time, np.ones((3, 2)), ["only_one"])
     with pytest.raises(ValueError):
         get_shape_check(time, np.ones((3, 3)), ["a", "b"])
+
+
+def test_get_shape_check_numpy2_compatibility():
+    """NumPy 2.0 scalar conversion uses Python int axis."""
+    time = np.arange(5)
+    data = np.ones((3, 5))
+    reshaped = get_shape_check(time, data, ["a", "b", "c"])
+    assert reshaped.shape == (5, 3)
+    assert np.array_equal(reshaped, np.ones((5, 3)))
+
+    square = np.ones((5, 5))
+    square_result = get_shape_check(time, square, list("abcde"))
+    assert square_result.shape == (5, 5)
+    assert np.array_equal(square_result, square)


### PR DESCRIPTION
> **Fixes #843** | Workflow: `24db82da`

## Summary

Ensures `get_shape_check` now converts the axis derived from `np.argwhere` into a Python `int`, preventing the NumPy 2.0 `TypeError` while reshaping data as requested in the issue. The existing default axis path is left untouched and the regression test verifies both the non-square and square scenarios stay safe.

## What Changed

### Modified Components

- `particula/util/convert_dtypes.py` - Extracts the axis via `np.argwhere(...).flatten()` and forces a Python `int` before calling `np.moveaxis`, with a short comment noting the NumPy 2.0 requirement.

### Tests Added/Updated

- `particula/util/tests/convert_dtypes_test.py` - Adds `test_get_shape_check_numpy2_compatibility` that exercises the argwhere path and confirms both the reshaped non-square case and square fallback behave correctly without raising `TypeError`.

## How It Works

The branch detection path now flattens the `np.argwhere` result and explicitly converts the first entry into a Python `int` before passing it to `np.moveaxis`, ensuring compatibility with NumPy 2.0’s stricter scalar handling while leaving the rest of the reshaping logic untouched.

## Implementation Notes

- **Why this approach**: Converting to `int` mirrors existing NumPy scalar handling elsewhere in the codebase and eliminates the breaking change without altering behavior.
- **Edge cases**: Square arrays still default to `axis=1`, and the new test double-checks that this path remains stable.

## Testing

- `pytest particula/util/tests/convert_dtypes_test.py`
- `pytest`