### PR TITLE
fix: #122 - [E1-F3-P2] Register CondensationIsothermalStaggeredBuilder in CondensationFactory with tests

### DIFF
--- a/particula/dynamics/condensation/condensation_factories.py
+++ b/particula/dynamics/condensation/condensation_factories.py
@@ -20,7 +20,13 @@ class CondensationFactory(
         CondensationStrategy,
     ]
 ):
-    """Factory class for condensation strategies."""
+    """Factory class for condensation strategies.
+
+    Supports strategy types:
+        - "isothermal": Standard isothermal condensation.
+        - "isothermal_staggered": Staggered isothermal condensation with
+          batch stepping for stability.
+    """
 
     def get_builders(
         self,


### PR DESCRIPTION
> **Fixes #122** | Workflow: `f808aa41`

## Summary
- Registers `CondensationIsothermalStaggeredBuilder` directly in `CondensationFactory` so string-based strategy selection now includes the staggered option and documents the supported strategies.
- Teaches the builder to ingest full parameter dictionaries, validate the payload, and log missing or invalid fields before instantiating a strategy.
- Exercises the new pathway via factory tests that assert both default parameters and custom settings (including `update_gases`) propagate through the factory to the built strategy.

## What Changed
### New Components
- `particula/dynamics/condensation/condensation_builder/condensation_isothermal_staggered_builder.py` - Adds logging, dictionary-based parameter intake, and validation around required keys and optional overrides (`theta_mode`, `num_batches`, `shuffle_each_step`, `random_state`, `update_gases`).

### Modified Components
- `particula/dynamics/condensation/condensation_factories.py` - Documents the available strategy types and keeps the factory mapping keyed by `"isothermal"` and `"isothermal_staggered"`, ensuring the new builder is returned when requested.
- `particula/dynamics/condensation/tests/condensation_factories_test.py` - Replaces the builder-map smoke checks with factory calls that assert the staggered strategy honors default parameters and a custom parameter set (non-default theta mode, batch count, shuffle flag, random seed, and `update_gases`).

### Tests Added/Updated
- `particula/dynamics/condensation/tests/condensation_factories_test.py` - Adds explicit `get_strategy("isothermal_staggered", ...)` scenarios for the defaults and non-default arguments, plus the continuing invalid-strategy guard.

## How It Works
The factory still exposes the two known strategy names, but now the staggered builder can be configured by passing the entire parameter dictionary. The builder logs any missing or unknown keys, validates units, and applies optional overrides before returning a ready-to-use `CondensationIsothermalStaggered` instance. Factory tests now call through to `CondensationFactory.get_strategy` so both the factory wiring and the builder’s new parameter handling are exercised together.

## Implementation Notes
- **Why this approach:** Centralizing parameter validation inside the builder keeps the factory lean and prevents invalid invocations from succeeding.
- **Error feedback:** Missing or extra keys raise a `ValueError` with logged context so integration errors are easier to diagnose.
- **Future consideration:** Additional optional parameters can be added to the valid-keys list once new builder setters are available.

## Testing
- `pytest particula/dynamics/condensation/tests/condensation_factories_test.py`
