### PR TITLE
fix: #147 - Fix NumPy array-to-scalar deprecation warnings in condensation tests

### DIFF
--- a/particula/integration_tests/condensation_particle_resolved_test.py
+++ b/particula/integration_tests/condensation_particle_resolved_test.py
@@ -123,7 +123,9 @@ class TestCondensationParticleResolved(unittest.TestCase):
         """Particle mass should increase while gas-phase water decreases."""
         initial_particle_mass = self.aerosol.particles.get_mass_concentration()
         initial_gas_water = (
-            self.aerosol.atmosphere.partitioning_species.get_concentration()[0]
+            self.aerosol.atmosphere.partitioning_species.get_concentration()[
+                0
+            ].item()
         )
 
         aerosol = self.aerosol
@@ -132,7 +134,9 @@ class TestCondensationParticleResolved(unittest.TestCase):
 
         final_particle_mass = aerosol.particles.get_mass_concentration()
         final_gas_water = (
-            aerosol.atmosphere.partitioning_species.get_concentration()[0]
+            aerosol.atmosphere.partitioning_species.get_concentration()[
+                0
+            ].item()
         )
 
         # assertions


### PR DESCRIPTION
> **Fixes #147** | Workflow: `b6a20310`
>
> ## Summary
>
> Avoid NumPy 1.25 deprecation complaints in the condensation integration test by explicitly extracting scalars from the `get_concentration()` result before comparing values. This keeps the test future-proof while preserving the original assertions.
>
> ## What Changed
>
> ### Modified Components
>
> - `particula/integration_tests/condensation_particle_resolved_test.py` - Both occurrences that previously relied on implicit scalar conversion from `get_concentration()[0]` now index once and call `.item()` to produce a proper scalar that survives NumPy 1.25+.
>
> ### Tests Added/Updated
>
> - No new tests were required; the existing integration test already covers the scenario in question.
>
> ## How It Works
>
> The test now explicitly extracts the scalar value when reading the first concentration entry so that the comparison logic is working with a real scalar instead of a size-1 array. Behaviourally nothing changes for the assertions, but future NumPy releases will no longer emit or raise deprecation warnings.
>
> ## Implementation Notes
>
> - **Why `.item()`**: NumPy now forbids implicitly converting non-0-d arrays to scalars. Calling `.item()` after indexing keeps the behaviour identical but safe for newer NumPy versions.
>
> ## Testing
>
> - `python -W error::DeprecationWarning -m pytest particula/integration_tests/condensation_particle_resolved_test.py -q`
> - `pytest`
> - `python -W error::DeprecationWarning -m pytest`
