### PR TITLE
docs: remove redundant license section from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,3 @@ particula/
 If you use Particula in your research, please cite:
 > Particula [Computer software]. DOI: [10.5281/zenodo.6634653](https://doi.org/10.5281/zenodo.6634653)
 
-## License
-
-MIT


### PR DESCRIPTION
**Target Branch:** `main`

## Summary

Removes a redundant license section from the readme to reduce duplication and keep the document clean.

## What Changed

### Modified Components

- `readme.md` - Removed 3 redundant lines from the license section

## Implementation Notes

- **Minor cleanup**: No functional changes, just documentation tidying
